### PR TITLE
update min az-cli version needed

### DIFF
--- a/azext_metadata.json
+++ b/azext_metadata.json
@@ -1,4 +1,4 @@
 {
-    "azext.minCliCoreVersion": "2.0.25",
+    "azext.minCliCoreVersion": "2.12.0",
     "version": "0.1.0"
   }


### PR DESCRIPTION
When April went to test, I realized that this was wrong since it didn't include the accurate min version