### PR TITLE
change the name of the extension to baremetal-infrastructure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open('HISTORY.rst', 'r', encoding='utf-8') as f:
     HISTORY = f.read()
 
 setup(
-    name='baremetal',
+    name='baremetal-infrastructure',
     version=VERSION,
     description='Additional commands for working with BareMetal instances.',
     long_description=README + '\n\n' + HISTORY,


### PR DESCRIPTION
Per @AprilZhaoWY 's suggestion, I am renaming the extension from `baremetal` to `baremetal-infrastructure`