### PR TITLE
fix the method that delete calls in the cli extension

### DIFF
--- a/azext_baremetalinfrastructure/custom.py
+++ b/azext_baremetalinfrastructure/custom.py
@@ -46,4 +46,4 @@ def update_baremetalinstance(client, resource_group_name, instance_name, **kwarg
     return client.update(resource_group_name, instance_name, kwargs['parameters'].tags)
 
 def delete_baremetalinstance(client, resource_group_name, instance_name):
-    return client.delete(resource_group_name, instance_name)
+    return client.begin_delete(resource_group_name, instance_name)


### PR DESCRIPTION
In the generated cli code, the api is actually called `begin_delete` instead of just `delete`, so the command was failing. This needs to be updated for the delete feature in the CLI to work