### PR TITLE
Make list/update calls point to latest GA API version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,3 +4,7 @@ Release History
 0.0.2 (2020-11-17)
 ++++++++++++++++++
 - fix the delete command so that it won't error out when called if the user has the correct permissions
+
+1.0.0 (2021-11-11)
+++++++++++++++++++
+- point list/update operations to new GA API version

--- a/azext_baremetalinfrastructure/modules_sdk/operations/_azure_bare_metal_instances_operations.py
+++ b/azext_baremetalinfrastructure/modules_sdk/operations/_azure_bare_metal_instances_operations.py
@@ -382,7 +382,7 @@ class AzureBareMetalInstancesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2020-08-06-preview"
+        api_version = "2021-08-09"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -453,7 +453,7 @@ class AzureBareMetalInstancesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2020-08-06-preview"
+        api_version = "2021-08-09"
         accept = "application/json"
 
         def prepare_request(next_link=None):
@@ -531,7 +531,7 @@ class AzureBareMetalInstancesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2020-08-06-preview"
+        api_version = "2021-08-09"
         accept = "application/json"
 
         # Construct URL
@@ -705,7 +705,7 @@ class AzureBareMetalInstancesOperations(object):
             401: ClientAuthenticationError, 404: ResourceNotFoundError, 409: ResourceExistsError
         }
         error_map.update(kwargs.pop('error_map', {}))
-        api_version = "2020-08-06-preview"
+        api_version =  "2021-08-09"
         content_type = kwargs.pop("content_type", "application/json")
         accept = "application/json"
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.0.2"
+VERSION = "1.0.0"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
For reference:

a. swagger changes for new BMI RP API version:  https://github.com/Azure/azure-rest-api-specs/pull/15680
b. Code changes in BMI RP to support new API version:  https://dev.azure.com/msazure/b32aa71e-8ed2-41b2-9d77-5bc261222004/_git/947a5884-ffdd-46e0-b92a-0469f2735787/pullrequest/4931300?_a=overview

Below commands were run locally to test that calls are made to required new API version after building the whl file:
a. az extension add --source dist/baremetal_infrastructure-1.0.0-py2.py3-none-any.whl
b. az baremetalinstance list --debug
```
cli.knack.cli: Command arguments: ['baremetalinstance', 'list', '--debug']
cli.knack.cli: __init__ debug log:
Enable color in terminal.
cli.knack.cli: Event: Cli.PreExecute []
cli.knack.cli: Event: CommandParser.OnGlobalArgumentsCreate [<function CLILogging.on_global_arguments at 0x7f8fe1ecebf8>, <function OutputProducer.on_global_arguments at 0x7f8fe19f8730>, <function CLIQuery.on_global_arguments at 0x7f8fe1a18840>]
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableCreate []
cli.azure.cli.core: Modules found from index for 'baremetalinstance': ['azext_baremetalinfrastructure']
cli.azure.cli.core: Loading command modules:
cli.azure.cli.core: Name                  Load Time    Groups  Commands
cli.azure.cli.core: Total (0)                 0.000         0         0
cli.azure.cli.core: These extensions are not installed and will be skipped: ['azext_ai_examples', 'azext_next']
cli.azure.cli.core: Loading extensions:
cli.azure.cli.core: Name                  Load Time    Groups  Commands  Directory
cli.azure.cli.core: baremetal-infrastructure      0.005         1         7  /home/shaaga/.azure/cliextensions/baremetal-infrastructure
cli.azure.cli.core: Total (1)                 0.005         1         7
cli.azure.cli.core: Loaded 1 groups, 7 commands.
cli.azure.cli.core: Found a match in the command table.
cli.azure.cli.core: Raw command  : baremetalinstance list
cli.azure.cli.core: Command table: baremetalinstance list
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableTruncate [<function AzCliLogging.init_command_file_logging at 0x7f8fe08ae0d0>]
cli.azure.cli.core.azlogging: metadata file logging enabled - writing logs to '/home/shaaga/.azure/commands/2021-11-11.11-56-30.baremetalinstance_list.3204.log'.
az_command_data_logger: command args: baremetalinstance list --debug
cli.knack.cli: Event: CommandInvoker.OnPreArgumentLoad [<function register_global_subscription_argument.<locals>.add_subscription_parameter at 0x7f8fe08d9048>, <function register_global_query_examples_argument.<locals>.register_query_examples at 0x7f8fe084c7b8>]
cli.knack.cli: Event: CommandInvoker.OnPostArgumentLoad []
cli.knack.cli: Event: CommandInvoker.OnPostCommandTableCreate [<function register_ids_argument.<locals>.add_ids_arguments at 0x7f8fe084c840>, <function register_cache_arguments.<locals>.add_cache_arguments at 0x7f8fe084c950>]
cli.knack.cli: Event: CommandInvoker.OnCommandTableLoaded []
cli.knack.cli: Event: CommandInvoker.OnPreParseArgs []
cli.knack.cli: Event: CommandInvoker.OnPostParseArgs [<function OutputProducer.handle_output_argument at 0x7f8fe19f87b8>, <function CLIQuery.handle_query_parameter at 0x7f8fe1a188c8>, <function register_global_query_examples_argument.<locals>.handle_example_parameter at 0x7f8fe084c730>, <function register_ids_argument.<locals>.parse_ids_arguments at 0x7f8fe084c8c8>]
az_command_data_logger: extension name: baremetal-infrastructure
az_command_data_logger: extension version: 1.0.0
cli.azure.cli.core.commands.client_factory: Getting management service client client_type=BareMetalInfrastructureClient
urllib3.util.retry: Converted retries value: 1 -> Retry(total=1, connect=None, read=None, redirect=None, status=None)
urllib3.connectionpool: Starting new HTTPS connection (1): login.microsoftonline.com:443
urllib3.connectionpool: https://login.microsoftonline.com:443 "GET /72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0/.well-known/openid-configuration HTTP/1.1" 200 1753
msal.authority: openid_config = {'token_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token', 'token_endpoint_auth_methods_supported': ['client_secret_post', 'private_key_jwt', 'client_secret_basic'], 'jwks_uri': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/discovery/v2.0/keys', 'response_modes_supported': ['query', 'fragment', 'form_post'], 'subject_types_supported': ['pairwise'], 'id_token_signing_alg_values_supported': ['RS256'], 'response_types_supported': ['code', 'id_token', 'code id_token', 'id_token token'], 'scopes_supported': ['openid', 'profile', 'email', 'offline_access'], 'issuer': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0', 'request_uri_parameter_supported': False, 'userinfo_endpoint': 'https://graph.microsoft.com/oidc/userinfo', 'authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/authorize', 'device_authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/devicecode', 'http_logout_supported': True, 'frontchannel_logout_supported': True, 'end_session_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/logout', 'claims_supported': ['sub', 'iss', 'cloud_instance_name', 'cloud_instance_host_name', 'cloud_graph_host_name', 'msgraph_host', 'aud', 'exp', 'iat', 'auth_time', 'acr', 'nonce', 'preferred_username', 'name', 'tid', 'ver', 'at_hash', 'c_hash', 'email'], 'kerberos_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/kerberos', 'tenant_region_scope': 'WW', 'cloud_instance_name': 'microsoftonline.com', 'cloud_graph_host_name': 'graph.windows.net', 'msgraph_host': 'graph.microsoft.com', 'rbac_url': 'https://pas.windows.net'}
cli.azure.cli.core.auth.credential_adaptor: CredentialAdaptor.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
cli.azure.cli.core.auth.msal_authentication: UserCredential.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
msal.application: Cache hit an AT
msal.telemetry: Generate or reuse correlation_id: ad74daaa-38cc-4888-8893-30c7ca13adbf
cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances?api-version=2021-08-09'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
cli.azure.cli.core.sdk.policies: Request headers:
cli.azure.cli.core.sdk.policies:     'Accept': 'application/json'
cli.azure.cli.core.sdk.policies:     'x-ms-client-request-id': '4ecf1872-42b8-11ec-8600-00155dd0215b'
cli.azure.cli.core.sdk.policies:     'CommandName': 'baremetalinstance list'
cli.azure.cli.core.sdk.policies:     'ParameterSetName': '--debug'
cli.azure.cli.core.sdk.policies:     'User-Agent': 'AZURECLI/2.30.0 (DEB) azsdk-python-mgmt-baremetalinfrastructure/1.0.0b1 Python/3.6.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-debian-buster-sid)'
cli.azure.cli.core.sdk.policies:     'Authorization': '*****'
cli.azure.cli.core.sdk.policies: Request body:
cli.azure.cli.core.sdk.policies: This request has no body
urllib3.connectionpool: Starting new HTTPS connection (1): management.azure.com:443
urllib3.connectionpool: https://management.azure.com:443 "GET /subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances?api-version=2021-08-09 HTTP/1.1" 200 2163
cli.azure.cli.core.sdk.policies: Response status: 200
cli.azure.cli.core.sdk.policies: Response headers:
cli.azure.cli.core.sdk.policies:     'Cache-Control': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Pragma': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Content-Type': 'application/json; charset=utf-8'
cli.azure.cli.core.sdk.policies:     'Content-Encoding': 'gzip'
cli.azure.cli.core.sdk.policies:     'Expires': '-1'
cli.azure.cli.core.sdk.policies:     'Vary': 'Accept-Encoding'
cli.azure.cli.core.sdk.policies:     'x-ms-original-request-ids': '10b31339-869b-418c-9bae-d44ef062f82d, ef425cda-05a1-48d8-ad45-da68045d032d, bdadaedf-3181-4089-a063-8bc11ec7a3d8'
cli.azure.cli.core.sdk.policies:     'x-ms-ratelimit-remaining-subscription-reads': '11998'
cli.azure.cli.core.sdk.policies:     'x-ms-request-id': '5691f460-37c7-447c-a460-004b62430bb5'
cli.azure.cli.core.sdk.policies:     'x-ms-correlation-request-id': '5691f460-37c7-447c-a460-004b62430bb5'
cli.azure.cli.core.sdk.policies:     'x-ms-routing-request-id': 'SOUTHINDIA:20211111T062638Z:5691f460-37c7-447c-a460-004b62430bb5'
cli.azure.cli.core.sdk.policies:     'Strict-Transport-Security': 'max-age=31536000; includeSubDomains'
cli.azure.cli.core.sdk.policies:     'X-Content-Type-Options': 'nosniff'
cli.azure.cli.core.sdk.policies:     'Date': 'Thu, 11 Nov 2021 06:26:38 GMT'
cli.azure.cli.core.sdk.policies:     'Content-Length': '2163'
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {"value":[{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4481","location":"eastus2","name":"sdflexopt4481","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{},"properties":{"azureBareMetalInstanceId":"46170418-1959-41e0-93f0-9728f2c924c9","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/NA-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"SDFLEX","azureBareMetalInstanceSize":"S448om"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.75"}],"circuitId":"/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"},"storageProfile":{"nfsIpAddress":"10.29.211.62","osDisks":[{"name":"t210_rhel_boot_sdflexoptane4481_lun","diskSizeGB":50}]},"osProfile":{"computerName":"sdflexopt4481","osType":"RHEL 7.9","version":"RHEL 7.9"},"provisioningState":"Succeeded"}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4482","location":"eastus2","name":"sdflexopt4482","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{},"properties":{"azureBareMetalInstanceId":"1b0640ec-3993-4534-8dfe-86f349c6ca20","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sdflexopt4482-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"SDFLEX","azureBareMetalInstanceSize":"S448om"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.76"}],"circuitId":"/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"},"storageProfile":{"nfsIpAddress":"10.29.211.63","osDisks":[{"name":"t210_rhel_boot_sdflexoptane4482_lun","diskSizeGB":50}]},"osProfile":{"computerName":"sdflexopt4482","osType":"RHEL 7.9","version":"RHEL 7.9"},"provisioningState":"Succeeded"}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41","location":"eastus2","name":"sollabdsm41","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{},"properties":{"azureBareMetalInstanceId":"859ebef9-c540-412b-88c6-391bfca1672b","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm41-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"Cisco_UCS","azureBareMetalInstanceSize":"S224om"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.41"}],"circuitId":"/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"},"storageProfile":{"nfsIpAddress":"10.29.211.51","osDisks":[{"name":"t210_li_sles_boot_sollabdsm41_lun_NEW","diskSizeGB":50}]},"osProfile":{"computerName":"sollabdsm41","osType":"SLES 12 SP4","version":"SLES 12 SP4"},"provisioningState":"Succeeded"}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm42","location":"eastus2","name":"sollabdsm42","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{},"properties":{"azureBareMetalInstanceId":"303d56b2-68d9-4686-87c2-c8be3c8f8f3a","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm42-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"Cisco_UCS","azureBareMetalInstanceSize":"S224om"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.42"}],"circuitId":"/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"},"storageProfile":{"nfsIpAddress":"10.29.211.52","osDisks":[{"name":"t210_li_sles_boot_sollabdsm42_lun","diskSizeGB":50}]},"osProfile":{"computerName":"sollabdsm42","osType":"SLES 12 SP4","version":"SLES 12 SP4"},"provisioningState":"Succeeded"}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/SAT09A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabsat063","location":"southcentralus","name":"sollabsat063","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{},"properties":{"azureBareMetalInstanceId":"45d071f2-cde1-4562-bd6e-4d3026ce602c","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/SAT09A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabsat063-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"Cisco_UCS","azureBareMetalInstanceSize":"S224om"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.63"}],"circuitId":"/subscriptions/84d94110-0e23-44fd-a49d-1c5f8dd60ea8/resourceGroups/T210_Cloud_Al-SAT09-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_Cloud_Al-SAT09-10GB"},"storageProfile":{"nfsIpAddress":"10.26.211.63","osDisks":[{"name":"t210_li_sles_boot_sollabsat063_lun","diskSizeGB":50}]},"osProfile":{"computerName":"sollabsat063","osType":"SLES 12 SP4","version":"SLES 12 SP4"},"provisioningState":"Succeeded"}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/azsollabdsm35","location":"centraluseuap","name":"azsollabdsm35","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{"lastModifiedBy":"balramc@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2021-10-07T14:46:23.3349530Z"},"properties":{"azureBareMetalInstanceId":"bec71cac-6d5a-42b7-8f78-72c2873815c0","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/azsollabdsm35-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"HPE","azureBareMetalInstanceSize":"S384"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.35"}],"circuitId":"/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb"},"storageProfile":{"nfsIpAddress":"10.20.211.150","osDisks":[{"name":"t210_sles_boot_azsollabdsm35_lun","diskSizeGB":50}]},"osProfile":{"computerName":"azsollabdsm35","osType":"SLES 15 SP1","version":"15 SP1"}}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/azsollabdsm36","location":"centraluseuap","name":"azsollabdsm36","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{"lastModifiedBy":"9d90ee23-90d4-4560-8501-7c683bf51b89","lastModifiedByType":"Application","lastModifiedAt":"2021-08-26T17:43:35.5099865Z"},"properties":{"azureBareMetalInstanceId":"45a7eeb1-41c4-4fe7-869e-7405fa4c14c9","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/azsollabdsm36-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"HPE","azureBareMetalInstanceSize":"S384"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.36"}],"circuitId":"/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb"},"storageProfile":{"nfsIpAddress":"10.20.211.151","osDisks":[{"name":"t250_sles_boot_sollabdsm36_lalit","diskSizeGB":50}]},"osProfile":{"computerName":"azsollabdsm36","osType":"SLES 12 SP4","version":"12 SP4"}}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm31","location":"centraluseuap","name":"sollabdsm31","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{"lastModifiedBy":"jaawasth@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2021-11-03T15:14:56.5480507Z"},"properties":{"azureBareMetalInstanceId":"47d88b30-f03c-47ef-baa2-3577455d4024","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm31-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"Cisco_UCS","azureBareMetalInstanceSize":"S192"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.31"}],"circuitId":"/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb"},"storageProfile":{"nfsIpAddress":"10.20.211.51","osDisks":[{"name":"t210_sles_boot_sollabdsm31","diskSizeGB":50}]},"osProfile":{"computerName":"sollabdsm31","osType":"SLES 12 SP3","version":"SLES 12 SP3"}}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32","location":"centraluseuap","name":"sollabdsm32","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{"lastModifiedBy":"shaaga@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2021-11-10T19:00:58.9872330Z"},"properties":{"azureBareMetalInstanceId":"370c6cd6-5ae6-42bf-91b3-dc01655c8578","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm32-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"Cisco_UCS","azureBareMetalInstanceSize":"S192"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.32"}],"circuitId":"/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb"},"storageProfile":{"nfsIpAddress":"10.20.211.52","osDisks":[{"name":"t210_sles_boot_sollabdsm32","diskSizeGB":50}]},"osProfile":{"computerName":"sollabdsm32","osType":"SLES 12 SP3","version":"SLES 12 SP3"}}},{"id":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/SWAP_HOST_01","location":"centraluseuap","name":"SWAP_HOST_01","tags":{},"type":"Microsoft.BareMetalInfrastructure/bareMetalInstances","systemData":{},"properties":{"azureBareMetalInstanceId":"f3c38ad8-08ea-4098-8ace-5742d18074f5","powerState":"started","proximityPlacementGroup":"/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/SWAP_HOST_01-ppg","hwRevision":"Rev 4.2","hardwareProfile":{"hardwareType":"SDFLEX","azureBareMetalInstanceSize":"S448"},"networkProfile":{"networkInterfaces":[{"ipAddress":"10.100.0.182"}],"circuitId":"/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb"},"storageProfile":{"nfsIpAddress":"10.20.211.182","osDisks":[{"name":"t210_sles_boot_swap_host_01_lun","diskSizeGB":50}]},"osProfile":{"computerName":"SWAP_HOST_01","osType":"SLES 15 SP1","version":"15 SP1"},"provisioningState":"Succeeded"}}]}
cli.knack.cli: Event: CommandInvoker.OnTransformResult [<function _resource_group_transform at 0x7f8fe088b268>, <function _x509_from_base64_to_hex_transform at 0x7f8fe088b2f0>]
cli.knack.cli: Event: CommandInvoker.OnFilterResult []
[
  {
    "azureBareMetalInstanceId": "46170418-1959-41e0-93f0-9728f2c924c9",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S448om",
      "hardwareType": "SDFLEX"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4481",
    "location": "eastus2",
    "name": "sdflexopt4481",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.75"
        }
      ]
    },
    "osProfile": {
      "computerName": "sdflexopt4481",
      "osType": "RHEL 7.9",
      "sshPublicKey": null,
      "version": "RHEL 7.9"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/NA-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.62",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_rhel_boot_sdflexoptane4481_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "1b0640ec-3993-4534-8dfe-86f349c6ca20",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S448om",
      "hardwareType": "SDFLEX"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4482",
    "location": "eastus2",
    "name": "sdflexopt4482",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.76"
        }
      ]
    },
    "osProfile": {
      "computerName": "sdflexopt4482",
      "osType": "RHEL 7.9",
      "sshPublicKey": null,
      "version": "RHEL 7.9"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sdflexopt4482-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.63",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_rhel_boot_sdflexoptane4482_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "859ebef9-c540-412b-88c6-391bfca1672b",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S224om",
      "hardwareType": "Cisco_UCS"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41",
    "location": "eastus2",
    "name": "sollabdsm41",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.41"
        }
      ]
    },
    "osProfile": {
      "computerName": "sollabdsm41",
      "osType": "SLES 12 SP4",
      "sshPublicKey": null,
      "version": "SLES 12 SP4"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm41-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.51",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_li_sles_boot_sollabdsm41_lun_NEW"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "303d56b2-68d9-4686-87c2-c8be3c8f8f3a",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S224om",
      "hardwareType": "Cisco_UCS"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm42",
    "location": "eastus2",
    "name": "sollabdsm42",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.42"
        }
      ]
    },
    "osProfile": {
      "computerName": "sollabdsm42",
      "osType": "SLES 12 SP4",
      "sshPublicKey": null,
      "version": "SLES 12 SP4"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm42-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.52",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_li_sles_boot_sollabdsm42_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "45d071f2-cde1-4562-bd6e-4d3026ce602c",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S224om",
      "hardwareType": "Cisco_UCS"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/SAT09A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabsat063",
    "location": "southcentralus",
    "name": "sollabsat063",
    "networkProfile": {
      "circuitId": "/subscriptions/84d94110-0e23-44fd-a49d-1c5f8dd60ea8/resourceGroups/T210_Cloud_Al-SAT09-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_Cloud_Al-SAT09-10GB",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.63"
        }
      ]
    },
    "osProfile": {
      "computerName": "sollabsat063",
      "osType": "SLES 12 SP4",
      "sshPublicKey": null,
      "version": "SLES 12 SP4"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/SAT09A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabsat063-ppg",
    "resourceGroup": "SAT09A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.26.211.63",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_li_sles_boot_sollabsat063_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "bec71cac-6d5a-42b7-8f78-72c2873815c0",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S384",
      "hardwareType": "HPE"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/azsollabdsm35",
    "location": "centraluseuap",
    "name": "azsollabdsm35",
    "networkProfile": {
      "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.35"
        }
      ]
    },
    "osProfile": {
      "computerName": "azsollabdsm35",
      "osType": "SLES 15 SP1",
      "sshPublicKey": null,
      "version": "15 SP1"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": null,
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/azsollabdsm35-ppg",
    "resourceGroup": "DSM05A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.20.211.150",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_sles_boot_azsollabdsm35_lun"
        }
      ]
    },
    "systemData": {
      "lastModifiedAt": "2021-10-07T14:46:23.3349530Z",
      "lastModifiedBy": "balramc@microsoft.com",
      "lastModifiedByType": "User"
    },
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "45a7eeb1-41c4-4fe7-869e-7405fa4c14c9",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S384",
      "hardwareType": "HPE"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/azsollabdsm36",
    "location": "centraluseuap",
    "name": "azsollabdsm36",
    "networkProfile": {
      "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.36"
        }
      ]
    },
    "osProfile": {
      "computerName": "azsollabdsm36",
      "osType": "SLES 12 SP4",
      "sshPublicKey": null,
      "version": "12 SP4"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": null,
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/azsollabdsm36-ppg",
    "resourceGroup": "DSM05A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.20.211.151",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t250_sles_boot_sollabdsm36_lalit"
        }
      ]
    },
    "systemData": {
      "lastModifiedAt": "2021-08-26T17:43:35.5099865Z",
      "lastModifiedBy": "9d90ee23-90d4-4560-8501-7c683bf51b89",
      "lastModifiedByType": "Application"
    },
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "47d88b30-f03c-47ef-baa2-3577455d4024",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S192",
      "hardwareType": "Cisco_UCS"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm31",
    "location": "centraluseuap",
    "name": "sollabdsm31",
    "networkProfile": {
      "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.31"
        }
      ]
    },
    "osProfile": {
      "computerName": "sollabdsm31",
      "osType": "SLES 12 SP3",
      "sshPublicKey": null,
      "version": "SLES 12 SP3"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": null,
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm31-ppg",
    "resourceGroup": "DSM05A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.20.211.51",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_sles_boot_sollabdsm31"
        }
      ]
    },
    "systemData": {
      "lastModifiedAt": "2021-11-03T15:14:56.5480507Z",
      "lastModifiedBy": "jaawasth@microsoft.com",
      "lastModifiedByType": "User"
    },
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "370c6cd6-5ae6-42bf-91b3-dc01655c8578",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S192",
      "hardwareType": "Cisco_UCS"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32",
    "location": "centraluseuap",
    "name": "sollabdsm32",
    "networkProfile": {
      "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.32"
        }
      ]
    },
    "osProfile": {
      "computerName": "sollabdsm32",
      "osType": "SLES 12 SP3",
      "sshPublicKey": null,
      "version": "SLES 12 SP3"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": null,
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm32-ppg",
    "resourceGroup": "DSM05A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.20.211.52",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_sles_boot_sollabdsm32"
        }
      ]
    },
    "systemData": {
      "lastModifiedAt": "2021-11-10T19:00:58.9872330Z",
      "lastModifiedBy": "shaaga@microsoft.com",
      "lastModifiedByType": "User"
    },
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "f3c38ad8-08ea-4098-8ace-5742d18074f5",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S448",
      "hardwareType": "SDFLEX"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/SWAP_HOST_01",
    "location": "centraluseuap",
    "name": "SWAP_HOST_01",
    "networkProfile": {
      "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.182"
        }
      ]
    },
    "osProfile": {
      "computerName": "SWAP_HOST_01",
      "osType": "SLES 15 SP1",
      "sshPublicKey": null,
      "version": "15 SP1"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/SWAP_HOST_01-ppg",
    "resourceGroup": "DSM05A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.20.211.182",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_sles_boot_swap_host_01_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  }
]
```
c. az baremetalinstance list --resource-group BN6A-T210 --debug

```
cli.knack.cli: Command arguments: ['baremetalinstance', 'list', '--resource-group', 'BN6A-T210', '--debug']
cli.knack.cli: __init__ debug log:
Enable color in terminal.
cli.knack.cli: Event: Cli.PreExecute []
cli.knack.cli: Event: CommandParser.OnGlobalArgumentsCreate [<function CLILogging.on_global_arguments at 0x7f6499d99bf8>, <function OutputProducer.on_global_arguments at 0x7f64998c3730>, <function CLIQuery.on_global_arguments at 0x7f64998e3840>]
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableCreate []
cli.azure.cli.core: Modules found from index for 'baremetalinstance': ['azext_baremetalinfrastructure']
cli.azure.cli.core: Loading command modules:
cli.azure.cli.core: Name                  Load Time    Groups  Commands
cli.azure.cli.core: Total (0)                 0.000         0         0
cli.azure.cli.core: These extensions are not installed and will be skipped: ['azext_ai_examples', 'azext_next']
cli.azure.cli.core: Loading extensions:
cli.azure.cli.core: Name                  Load Time    Groups  Commands  Directory
cli.azure.cli.core: baremetal-infrastructure      0.006         1         7  /home/shaaga/.azure/cliextensions/baremetal-infrastructure
cli.azure.cli.core: Total (1)                 0.006         1         7
cli.azure.cli.core: Loaded 1 groups, 7 commands.
cli.azure.cli.core: Found a match in the command table.
cli.azure.cli.core: Raw command  : baremetalinstance list
cli.azure.cli.core: Command table: baremetalinstance list
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableTruncate [<function AzCliLogging.init_command_file_logging at 0x7f64987790d0>]
cli.azure.cli.core.azlogging: metadata file logging enabled - writing logs to '/home/shaaga/.azure/commands/2021-11-11.12-03-57.baremetalinstance_list.3323.log'.
az_command_data_logger: command args: baremetalinstance list --resource-group {} --debug
cli.knack.cli: Event: CommandInvoker.OnPreArgumentLoad [<function register_global_subscription_argument.<locals>.add_subscription_parameter at 0x7f64987a4048>, <function register_global_query_examples_argument.<locals>.register_query_examples at 0x7f64987197b8>]
cli.knack.cli: Event: CommandInvoker.OnPostArgumentLoad []
cli.knack.cli: Event: CommandInvoker.OnPostCommandTableCreate [<function register_ids_argument.<locals>.add_ids_arguments at 0x7f6498719840>, <function register_cache_arguments.<locals>.add_cache_arguments at 0x7f6498719950>]
cli.knack.cli: Event: CommandInvoker.OnCommandTableLoaded []
cli.knack.cli: Event: CommandInvoker.OnPreParseArgs []
cli.knack.cli: Event: CommandInvoker.OnPostParseArgs [<function OutputProducer.handle_output_argument at 0x7f64998c37b8>, <function CLIQuery.handle_query_parameter at 0x7f64998e38c8>, <function register_global_query_examples_argument.<locals>.handle_example_parameter at 0x7f6498719730>, <function register_ids_argument.<locals>.parse_ids_arguments at 0x7f64987198c8>]
az_command_data_logger: extension name: baremetal-infrastructure
az_command_data_logger: extension version: 1.0.0
cli.azure.cli.core.commands.client_factory: Getting management service client client_type=BareMetalInfrastructureClient
urllib3.util.retry: Converted retries value: 1 -> Retry(total=1, connect=None, read=None, redirect=None, status=None)
urllib3.connectionpool: Starting new HTTPS connection (1): login.microsoftonline.com:443
urllib3.connectionpool: https://login.microsoftonline.com:443 "GET /72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0/.well-known/openid-configuration HTTP/1.1" 200 1753
msal.authority: openid_config = {'token_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token', 'token_endpoint_auth_methods_supported': ['client_secret_post', 'private_key_jwt', 'client_secret_basic'], 'jwks_uri': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/discovery/v2.0/keys', 'response_modes_supported': ['query', 'fragment', 'form_post'], 'subject_types_supported': ['pairwise'], 'id_token_signing_alg_values_supported': ['RS256'], 'response_types_supported': ['code', 'id_token', 'code id_token', 'id_token token'], 'scopes_supported': ['openid', 'profile', 'email', 'offline_access'], 'issuer': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0', 'request_uri_parameter_supported': False, 'userinfo_endpoint': 'https://graph.microsoft.com/oidc/userinfo', 'authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/authorize', 'device_authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/devicecode', 'http_logout_supported': True, 'frontchannel_logout_supported': True, 'end_session_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/logout', 'claims_supported': ['sub', 'iss', 'cloud_instance_name', 'cloud_instance_host_name', 'cloud_graph_host_name', 'msgraph_host', 'aud', 'exp', 'iat', 'auth_time', 'acr', 'nonce', 'preferred_username', 'name', 'tid', 'ver', 'at_hash', 'c_hash', 'email'], 'kerberos_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/kerberos', 'tenant_region_scope': 'WW', 'cloud_instance_name': 'microsoftonline.com', 'cloud_graph_host_name': 'graph.windows.net', 'msgraph_host': 'graph.microsoft.com', 'rbac_url': 'https://pas.windows.net'}
cli.azure.cli.core.auth.credential_adaptor: CredentialAdaptor.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
cli.azure.cli.core.auth.msal_authentication: UserCredential.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
msal.application: Cache hit an AT
msal.telemetry: Generate or reuse correlation_id: e54172a6-5aed-4aaa-9770-e8584e558046
cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances?api-version=2021-08-09'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
cli.azure.cli.core.sdk.policies: Request headers:
cli.azure.cli.core.sdk.policies:     'Accept': 'application/json'
cli.azure.cli.core.sdk.policies:     'x-ms-client-request-id': '596435be-42b9-11ec-ad7e-00155dd0215b'
cli.azure.cli.core.sdk.policies:     'CommandName': 'baremetalinstance list'
cli.azure.cli.core.sdk.policies:     'ParameterSetName': '--resource-group --debug'
cli.azure.cli.core.sdk.policies:     'User-Agent': 'AZURECLI/2.30.0 (DEB) azsdk-python-mgmt-baremetalinfrastructure/1.0.0b1 Python/3.6.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-debian-buster-sid)'
cli.azure.cli.core.sdk.policies:     'Authorization': '*****'
cli.azure.cli.core.sdk.policies: Request body:
cli.azure.cli.core.sdk.policies: This request has no body
urllib3.connectionpool: Starting new HTTPS connection (1): management.azure.com:443
urllib3.connectionpool: https://management.azure.com:443 "GET /subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances?api-version=2021-08-09 HTTP/1.1" 200 None
cli.azure.cli.core.sdk.policies: Response status: 200
cli.azure.cli.core.sdk.policies: Response headers:
cli.azure.cli.core.sdk.policies:     'Cache-Control': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Pragma': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Transfer-Encoding': 'chunked'
cli.azure.cli.core.sdk.policies:     'Content-Type': 'application/json'
cli.azure.cli.core.sdk.policies:     'Content-Encoding': 'gzip'
cli.azure.cli.core.sdk.policies:     'Expires': '-1'
cli.azure.cli.core.sdk.policies:     'Vary': 'Accept-Encoding,Accept-Encoding'
cli.azure.cli.core.sdk.policies:     'x-ms-routing-request-id': 'SOUTHINDIA:20211111T063405Z:6d54823a-e95e-410b-8d62-881d821d7303'
cli.azure.cli.core.sdk.policies:     'x-ms-ratelimit-remaining-subscription-reads': '11999'
cli.azure.cli.core.sdk.policies:     'x-ms-correlation-request-id': '6d54823a-e95e-410b-8d62-881d821d7303'
cli.azure.cli.core.sdk.policies:     'x-ms-request-id': '7fe98739-07d9-4a2f-86a4-d6375a49f0ea'
cli.azure.cli.core.sdk.policies:     'Strict-Transport-Security': 'max-age=31536000; includeSubDomains'
cli.azure.cli.core.sdk.policies:     'Server': 'nginx/1.19.1'
cli.azure.cli.core.sdk.policies:     'X-Content-Type-Options': 'nosniff'
cli.azure.cli.core.sdk.policies:     'Date': 'Thu, 11 Nov 2021 06:34:04 GMT'
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {
  "value": [
   {
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4481",
    "location": "eastus2",
    "name": "sdflexopt4481",
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances",
    "systemData": {},
    "properties": {
     "azureBareMetalInstanceId": "46170418-1959-41e0-93f0-9728f2c924c9",
     "powerState": "started",
     "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/NA-ppg",
     "hwRevision": "Rev 4.2",
     "hardwareProfile": {
      "hardwareType": "SDFLEX",
      "azureBareMetalInstanceSize": "S448om"
     },
     "networkProfile": {
      "networkInterfaces": [
       {
        "ipAddress": "10.100.0.75"
       }
      ],
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"
     },
     "storageProfile": {
      "nfsIpAddress": "10.29.211.62",
      "osDisks": [
       {
        "name": "t210_rhel_boot_sdflexoptane4481_lun",
        "diskSizeGB": 50
       }
      ]
     },
     "osProfile": {
      "computerName": "sdflexopt4481",
      "osType": "RHEL 7.9",
      "version": "RHEL 7.9"
     },
     "provisioningState": "Succeeded"
    }
   },
   {
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4482",
    "location": "eastus2",
    "name": "sdflexopt4482",
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances",
    "systemData": {},
    "properties": {
     "azureBareMetalInstanceId": "1b0640ec-3993-4534-8dfe-86f349c6ca20",
     "powerState": "started",
     "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sdflexopt4482-ppg",
     "hwRevision": "Rev 4.2",
     "hardwareProfile": {
      "hardwareType": "SDFLEX",
      "azureBareMetalInstanceSize": "S448om"
     },
     "networkProfile": {
      "networkInterfaces": [
       {
        "ipAddress": "10.100.0.76"
       }
      ],
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"
     },
     "storageProfile": {
      "nfsIpAddress": "10.29.211.63",
      "osDisks": [
       {
        "name": "t210_rhel_boot_sdflexoptane4482_lun",
        "diskSizeGB": 50
       }
      ]
     },
     "osProfile": {
      "computerName": "sdflexopt4482",
      "osType": "RHEL 7.9",
      "version": "RHEL 7.9"
     },
     "provisioningState": "Succeeded"
    }
   },
   {
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41",
    "location": "eastus2",
    "name": "sollabdsm41",
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances",
    "systemData": {},
    "properties": {
     "azureBareMetalInstanceId": "859ebef9-c540-412b-88c6-391bfca1672b",
     "powerState": "started",
     "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm41-ppg",
     "hwRevision": "Rev 4.2",
     "hardwareProfile": {
      "hardwareType": "Cisco_UCS",
      "azureBareMetalInstanceSize": "S224om"
     },
     "networkProfile": {
      "networkInterfaces": [
       {
        "ipAddress": "10.100.0.41"
       }
      ],
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"
     },
     "storageProfile": {
      "nfsIpAddress": "10.29.211.51",
      "osDisks": [
       {
        "name": "t210_li_sles_boot_sollabdsm41_lun_NEW",
        "diskSizeGB": 50
       }
      ]
     },
     "osProfile": {
      "computerName": "sollabdsm41",
      "osType": "SLES 12 SP4",
      "version": "SLES 12 SP4"
     },
     "provisioningState": "Succeeded"
    }
   },
   {
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm42",
    "location": "eastus2",
    "name": "sollabdsm42",
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances",
    "systemData": {},
    "properties": {
     "azureBareMetalInstanceId": "303d56b2-68d9-4686-87c2-c8be3c8f8f3a",
     "powerState": "started",
     "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm42-ppg",
     "hwRevision": "Rev 4.2",
     "hardwareProfile": {
      "hardwareType": "Cisco_UCS",
      "azureBareMetalInstanceSize": "S224om"
     },
     "networkProfile": {
      "networkInterfaces": [
       {
        "ipAddress": "10.100.0.42"
       }
      ],
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"
     },
     "storageProfile": {
      "nfsIpAddress": "10.29.211.52",
      "osDisks": [
       {
        "name": "t210_li_sles_boot_sollabdsm42_lun",
        "diskSizeGB": 50
       }
      ]
     },
     "osProfile": {
      "computerName": "sollabdsm42",
      "osType": "SLES 12 SP4",
      "version": "SLES 12 SP4"
     },
     "provisioningState": "Succeeded"
    }
   }
  ]
 }
cli.knack.cli: Event: CommandInvoker.OnTransformResult [<function _resource_group_transform at 0x7f6498756268>, <function _x509_from_base64_to_hex_transform at 0x7f64987562f0>]
cli.knack.cli: Event: CommandInvoker.OnFilterResult []
[
  {
    "azureBareMetalInstanceId": "46170418-1959-41e0-93f0-9728f2c924c9",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S448om",
      "hardwareType": "SDFLEX"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4481",
    "location": "eastus2",
    "name": "sdflexopt4481",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.75"
        }
      ]
    },
    "osProfile": {
      "computerName": "sdflexopt4481",
      "osType": "RHEL 7.9",
      "sshPublicKey": null,
      "version": "RHEL 7.9"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/NA-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.62",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_rhel_boot_sdflexoptane4481_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "1b0640ec-3993-4534-8dfe-86f349c6ca20",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S448om",
      "hardwareType": "SDFLEX"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sdflexopt4482",
    "location": "eastus2",
    "name": "sdflexopt4482",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.76"
        }
      ]
    },
    "osProfile": {
      "computerName": "sdflexopt4482",
      "osType": "RHEL 7.9",
      "sshPublicKey": null,
      "version": "RHEL 7.9"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sdflexopt4482-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.63",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_rhel_boot_sdflexoptane4482_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "859ebef9-c540-412b-88c6-391bfca1672b",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S224om",
      "hardwareType": "Cisco_UCS"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41",
    "location": "eastus2",
    "name": "sollabdsm41",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.41"
        }
      ]
    },
    "osProfile": {
      "computerName": "sollabdsm41",
      "osType": "SLES 12 SP4",
      "sshPublicKey": null,
      "version": "SLES 12 SP4"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm41-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.51",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_li_sles_boot_sollabdsm41_lun_NEW"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  },
  {
    "azureBareMetalInstanceId": "303d56b2-68d9-4686-87c2-c8be3c8f8f3a",
    "hardwareProfile": {
      "azureBareMetalInstanceSize": "S224om",
      "hardwareType": "Cisco_UCS"
    },
    "hwRevision": "Rev 4.2",
    "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm42",
    "location": "eastus2",
    "name": "sollabdsm42",
    "networkProfile": {
      "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
      "networkInterfaces": [
        {
          "ipAddress": "10.100.0.42"
        }
      ]
    },
    "osProfile": {
      "computerName": "sollabdsm42",
      "osType": "SLES 12 SP4",
      "sshPublicKey": null,
      "version": "SLES 12 SP4"
    },
    "partnerNodeId": null,
    "powerState": "started",
    "provisioningState": "Succeeded",
    "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm42-ppg",
    "resourceGroup": "BN6A-T210",
    "storageProfile": {
      "nfsIpAddress": "10.29.211.52",
      "osDisks": [
        {
          "diskSizeGb": 50,
          "lun": null,
          "name": "t210_li_sles_boot_sollabdsm42_lun"
        }
      ]
    },
    "systemData": {},
    "tags": {},
    "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
  }
]
```

d. az baremetalinstance show --resource-group BN6A-T210 --instance-name sollabdsm41 --debug
```
cli.knack.cli: Command arguments: ['baremetalinstance', 'show', '--resource-group', 'BN6A-T210', '--instance-name', 'sollabdsm41', '--debug']
cli.knack.cli: __init__ debug log:
Enable color in terminal.
cli.knack.cli: Event: Cli.PreExecute []
cli.knack.cli: Event: CommandParser.OnGlobalArgumentsCreate [<function CLILogging.on_global_arguments at 0x7faa60cbbbf8>, <function OutputProducer.on_global_arguments at 0x7faa607e5730>, <function CLIQuery.on_global_arguments at 0x7faa60805840>]
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableCreate []
cli.azure.cli.core: Modules found from index for 'baremetalinstance': ['azext_baremetalinfrastructure']
cli.azure.cli.core: Loading command modules:
cli.azure.cli.core: Name                  Load Time    Groups  Commands
cli.azure.cli.core: Total (0)                 0.000         0         0
cli.azure.cli.core: These extensions are not installed and will be skipped: ['azext_ai_examples', 'azext_next']
cli.azure.cli.core: Loading extensions:
cli.azure.cli.core: Name                  Load Time    Groups  Commands  Directory
cli.azure.cli.core: baremetal-infrastructure      0.005         1         7  /home/shaaga/.azure/cliextensions/baremetal-infrastructure
cli.azure.cli.core: Total (1)                 0.005         1         7
cli.azure.cli.core: Loaded 1 groups, 7 commands.
cli.azure.cli.core: Found a match in the command table.
cli.azure.cli.core: Raw command  : baremetalinstance show
cli.azure.cli.core: Command table: baremetalinstance show
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableTruncate [<function AzCliLogging.init_command_file_logging at 0x7faa5f69b0d0>]
cli.azure.cli.core.azlogging: metadata file logging enabled - writing logs to '/home/shaaga/.azure/commands/2021-11-11.12-13-12.baremetalinstance_show.3499.log'.
az_command_data_logger: command args: baremetalinstance show --resource-group {} --instance-name {} --debug
cli.knack.cli: Event: CommandInvoker.OnPreArgumentLoad [<function register_global_subscription_argument.<locals>.add_subscription_parameter at 0x7faa5f6c6048>, <function register_global_query_examples_argument.<locals>.register_query_examples at 0x7faa5f63b7b8>]
cli.knack.cli: Event: CommandInvoker.OnPostArgumentLoad []
cli.knack.cli: Event: CommandInvoker.OnPostCommandTableCreate [<function register_ids_argument.<locals>.add_ids_arguments at 0x7faa5f63b840>, <function register_cache_arguments.<locals>.add_cache_arguments at 0x7faa5f63b950>]
cli.knack.cli: Event: CommandInvoker.OnCommandTableLoaded []
cli.knack.cli: Event: CommandInvoker.OnPreParseArgs []
cli.knack.cli: Event: CommandInvoker.OnPostParseArgs [<function OutputProducer.handle_output_argument at 0x7faa607e57b8>, <function CLIQuery.handle_query_parameter at 0x7faa608058c8>, <function register_global_query_examples_argument.<locals>.handle_example_parameter at 0x7faa5f63b730>, <function register_ids_argument.<locals>.parse_ids_arguments at 0x7faa5f63b8c8>]
az_command_data_logger: extension name: baremetal-infrastructure
az_command_data_logger: extension version: 1.0.0
cli.azure.cli.core.commands.client_factory: Getting management service client client_type=BareMetalInfrastructureClient
urllib3.util.retry: Converted retries value: 1 -> Retry(total=1, connect=None, read=None, redirect=None, status=None)
urllib3.connectionpool: Starting new HTTPS connection (1): login.microsoftonline.com:443
urllib3.connectionpool: https://login.microsoftonline.com:443 "GET /72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0/.well-known/openid-configuration HTTP/1.1" 200 1753
msal.authority: openid_config = {'token_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token', 'token_endpoint_auth_methods_supported': ['client_secret_post', 'private_key_jwt', 'client_secret_basic'], 'jwks_uri': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/discovery/v2.0/keys', 'response_modes_supported': ['query', 'fragment', 'form_post'], 'subject_types_supported': ['pairwise'], 'id_token_signing_alg_values_supported': ['RS256'], 'response_types_supported': ['code', 'id_token', 'code id_token', 'id_token token'], 'scopes_supported': ['openid', 'profile', 'email', 'offline_access'], 'issuer': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0', 'request_uri_parameter_supported': False, 'userinfo_endpoint': 'https://graph.microsoft.com/oidc/userinfo', 'authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/authorize', 'device_authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/devicecode', 'http_logout_supported': True, 'frontchannel_logout_supported': True, 'end_session_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/logout', 'claims_supported': ['sub', 'iss', 'cloud_instance_name', 'cloud_instance_host_name', 'cloud_graph_host_name', 'msgraph_host', 'aud', 'exp', 'iat', 'auth_time', 'acr', 'nonce', 'preferred_username', 'name', 'tid', 'ver', 'at_hash', 'c_hash', 'email'], 'kerberos_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/kerberos', 'tenant_region_scope': 'WW', 'cloud_instance_name': 'microsoftonline.com', 'cloud_graph_host_name': 'graph.windows.net', 'msgraph_host': 'graph.microsoft.com', 'rbac_url': 'https://pas.windows.net'}
cli.azure.cli.core.auth.credential_adaptor: CredentialAdaptor.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
cli.azure.cli.core.auth.msal_authentication: UserCredential.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
msal.application: Cache hit an AT
msal.telemetry: Generate or reuse correlation_id: dcfc1a1d-eb9a-4a76-be17-3f729660f0f7
cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41?api-version=2021-08-09'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
cli.azure.cli.core.sdk.policies: Request headers:
cli.azure.cli.core.sdk.policies:     'Accept': 'application/json'
cli.azure.cli.core.sdk.policies:     'x-ms-client-request-id': 'a41539d6-42ba-11ec-b8c4-00155dd0215b'
cli.azure.cli.core.sdk.policies:     'CommandName': 'baremetalinstance show'
cli.azure.cli.core.sdk.policies:     'ParameterSetName': '--resource-group --instance-name --debug'
cli.azure.cli.core.sdk.policies:     'User-Agent': 'AZURECLI/2.30.0 (DEB) azsdk-python-mgmt-baremetalinfrastructure/1.0.0b1 Python/3.6.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-debian-buster-sid)'
cli.azure.cli.core.sdk.policies:     'Authorization': '*****'
cli.azure.cli.core.sdk.policies: Request body:
cli.azure.cli.core.sdk.policies: This request has no body
urllib3.connectionpool: Starting new HTTPS connection (1): management.azure.com:443
urllib3.connectionpool: https://management.azure.com:443 "GET /subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41?api-version=2021-08-09 HTTP/1.1" 200 None
cli.azure.cli.core.sdk.policies: Response status: 200
cli.azure.cli.core.sdk.policies: Response headers:
cli.azure.cli.core.sdk.policies:     'Cache-Control': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Pragma': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Transfer-Encoding': 'chunked'
cli.azure.cli.core.sdk.policies:     'Content-Type': 'application/json'
cli.azure.cli.core.sdk.policies:     'Content-Encoding': 'gzip'
cli.azure.cli.core.sdk.policies:     'Expires': '-1'
cli.azure.cli.core.sdk.policies:     'Vary': 'Accept-Encoding,Accept-Encoding'
cli.azure.cli.core.sdk.policies:     'x-ms-routing-request-id': 'SOUTHINDIA:20211111T064320Z:83b53518-986f-49b6-96ef-01cf4f7510b0'
cli.azure.cli.core.sdk.policies:     'x-ms-ratelimit-remaining-subscription-reads': '11999'
cli.azure.cli.core.sdk.policies:     'x-ms-correlation-request-id': '83b53518-986f-49b6-96ef-01cf4f7510b0'
cli.azure.cli.core.sdk.policies:     'x-ms-request-id': 'bbe432bf-6c78-4deb-8575-c9bb6aa314ea'
cli.azure.cli.core.sdk.policies:     'Strict-Transport-Security': 'max-age=31536000; includeSubDomains'
cli.azure.cli.core.sdk.policies:     'Server': 'nginx/1.19.1'
cli.azure.cli.core.sdk.policies:     'X-Content-Type-Options': 'nosniff'
cli.azure.cli.core.sdk.policies:     'Date': 'Thu, 11 Nov 2021 06:43:20 GMT'
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {
  "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41",
  "location": "eastus2",
  "name": "sollabdsm41",
  "tags": {},
  "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances",
  "systemData": {},
  "properties": {
   "azureBareMetalInstanceId": "859ebef9-c540-412b-88c6-391bfca1672b",
   "powerState": "started",
   "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm41-ppg",
   "hwRevision": "Rev 4.2",
   "hardwareProfile": {
    "hardwareType": "Cisco_UCS",
    "azureBareMetalInstanceSize": "S224om"
   },
   "networkProfile": {
    "networkInterfaces": [
     {
      "ipAddress": "10.100.0.41"
     }
    ],
    "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb"
   },
   "storageProfile": {
    "nfsIpAddress": "10.29.211.51",
    "osDisks": [
     {
      "name": "t210_li_sles_boot_sollabdsm41_lun_NEW",
      "diskSizeGB": 50
     }
    ]
   },
   "osProfile": {
    "computerName": "sollabdsm41",
    "osType": "SLES 12 SP4",
    "version": "SLES 12 SP4"
   },
   "provisioningState": "Succeeded"
  }
 }
cli.knack.cli: Event: CommandInvoker.OnTransformResult [<function _resource_group_transform at 0x7faa5f678268>, <function _x509_from_base64_to_hex_transform at 0x7faa5f6782f0>]
cli.knack.cli: Event: CommandInvoker.OnFilterResult []
{
  "azureBareMetalInstanceId": "859ebef9-c540-412b-88c6-391bfca1672b",
  "hardwareProfile": {
    "azureBareMetalInstanceSize": "S224om",
    "hardwareType": "Cisco_UCS"
  },
  "hwRevision": "Rev 4.2",
  "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/BN6A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm41",
  "location": "eastus2",
  "name": "sollabdsm41",
  "networkProfile": {
    "circuitId": "/subscriptions/921ee724-bf48-48dd-b819-11cc32bcdf7b/resourceGroups/T210_SOLLAB-USE02-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_SOLLAB-USE02-10Gb",
    "networkInterfaces": [
      {
        "ipAddress": "10.100.0.41"
      }
    ]
  },
  "osProfile": {
    "computerName": "sollabdsm41",
    "osType": "SLES 12 SP4",
    "sshPublicKey": null,
    "version": "SLES 12 SP4"
  },
  "partnerNodeId": null,
  "powerState": "started",
  "provisioningState": "Succeeded",
  "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/BN6A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm41-ppg",
  "resourceGroup": "BN6A-T210",
  "storageProfile": {
    "nfsIpAddress": "10.29.211.51",
    "osDisks": [
      {
        "diskSizeGb": 50,
        "lun": null,
        "name": "t210_li_sles_boot_sollabdsm41_lun_NEW"
      }
    ]
  },
  "systemData": {},
  "tags": {},
  "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
}
```
e. az baremetalinstance update --resource-group DSM05A-T210 --instance-name sollabdsm32 --debug

```
cli.knack.cli: Command arguments: ['baremetalinstance', 'update', '--resource-group', 'DSM05A-T210', '--instance-name', 'sollabdsm32', '--debug']
cli.knack.cli: __init__ debug log:
Enable color in terminal.
cli.knack.cli: Event: Cli.PreExecute []
cli.knack.cli: Event: CommandParser.OnGlobalArgumentsCreate [<function CLILogging.on_global_arguments at 0x7f9a6063fbf8>, <function OutputProducer.on_global_arguments at 0x7f9a60169730>, <function CLIQuery.on_global_arguments at 0x7f9a60189840>]
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableCreate []
cli.azure.cli.core: Modules found from index for 'baremetalinstance': ['azext_baremetalinfrastructure']
cli.azure.cli.core: Loading command modules:
cli.azure.cli.core: Name                  Load Time    Groups  Commands
cli.azure.cli.core: Total (0)                 0.000         0         0
cli.azure.cli.core: These extensions are not installed and will be skipped: ['azext_ai_examples', 'azext_next']
cli.azure.cli.core: Loading extensions:
cli.azure.cli.core: Name                  Load Time    Groups  Commands  Directory
cli.azure.cli.core: baremetal-infrastructure      0.006         1         7  /home/shaaga/.azure/cliextensions/baremetal-infrastructure
cli.azure.cli.core: Total (1)                 0.006         1         7
cli.azure.cli.core: Loaded 1 groups, 7 commands.
cli.azure.cli.core: Found a match in the command table.
cli.azure.cli.core: Raw command  : baremetalinstance update
cli.azure.cli.core: Command table: baremetalinstance update
cli.knack.cli: Event: CommandInvoker.OnPreCommandTableTruncate [<function AzCliLogging.init_command_file_logging at 0x7f9a5f01f0d0>]
cli.azure.cli.core.azlogging: metadata file logging enabled - writing logs to '/home/shaaga/.azure/commands/2021-11-11.13-23-28.baremetalinstance_update.4857.log'.
az_command_data_logger: command args: baremetalinstance update --resource-group {} --instance-name {} --debug
cli.knack.cli: Event: CommandInvoker.OnPreArgumentLoad [<function register_global_subscription_argument.<locals>.add_subscription_parameter at 0x7f9a5f00a8c8>, <function register_global_query_examples_argument.<locals>.register_query_examples at 0x7f9a5efbc7b8>]
cli.knack.cli: Event: CommandInvoker.OnPostArgumentLoad []
cli.knack.cli: Event: CommandInvoker.OnPostCommandTableCreate [<function register_ids_argument.<locals>.add_ids_arguments at 0x7f9a5efbc840>, <function register_cache_arguments.<locals>.add_cache_arguments at 0x7f9a5efbc950>]
cli.knack.cli: Event: CommandInvoker.OnCommandTableLoaded []
cli.knack.cli: Event: CommandInvoker.OnPreParseArgs []
cli.knack.cli: Event: CommandInvoker.OnPostParseArgs [<function OutputProducer.handle_output_argument at 0x7f9a601697b8>, <function CLIQuery.handle_query_parameter at 0x7f9a601898c8>, <function register_global_query_examples_argument.<locals>.handle_example_parameter at 0x7f9a5efbc730>, <function register_ids_argument.<locals>.parse_ids_arguments at 0x7f9a5efbc8c8>]
az_command_data_logger: extension name: baremetal-infrastructure
az_command_data_logger: extension version: 1.0.0
cli.azure.cli.core.commands.client_factory: Getting management service client client_type=BareMetalInfrastructureClient
urllib3.util.retry: Converted retries value: 1 -> Retry(total=1, connect=None, read=None, redirect=None, status=None)
urllib3.connectionpool: Starting new HTTPS connection (1): login.microsoftonline.com:443
urllib3.connectionpool: https://login.microsoftonline.com:443 "GET /72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0/.well-known/openid-configuration HTTP/1.1" 200 1753
msal.authority: openid_config = {'token_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token', 'token_endpoint_auth_methods_supported': ['client_secret_post', 'private_key_jwt', 'client_secret_basic'], 'jwks_uri': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/discovery/v2.0/keys', 'response_modes_supported': ['query', 'fragment', 'form_post'], 'subject_types_supported': ['pairwise'], 'id_token_signing_alg_values_supported': ['RS256'], 'response_types_supported': ['code', 'id_token', 'code id_token', 'id_token token'], 'scopes_supported': ['openid', 'profile', 'email', 'offline_access'], 'issuer': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0', 'request_uri_parameter_supported': False, 'userinfo_endpoint': 'https://graph.microsoft.com/oidc/userinfo', 'authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/authorize', 'device_authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/devicecode', 'http_logout_supported': True, 'frontchannel_logout_supported': True, 'end_session_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/logout', 'claims_supported': ['sub', 'iss', 'cloud_instance_name', 'cloud_instance_host_name', 'cloud_graph_host_name', 'msgraph_host', 'aud', 'exp', 'iat', 'auth_time', 'acr', 'nonce', 'preferred_username', 'name', 'tid', 'ver', 'at_hash', 'c_hash', 'email'], 'kerberos_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/kerberos', 'tenant_region_scope': 'WW', 'cloud_instance_name': 'microsoftonline.com', 'cloud_graph_host_name': 'graph.windows.net', 'msgraph_host': 'graph.microsoft.com', 'rbac_url': 'https://pas.windows.net'}
cli.azure.cli.core.auth.credential_adaptor: CredentialAdaptor.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
cli.azure.cli.core.auth.msal_authentication: UserCredential.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
msal.application: Found 1 RTs matching {'environment': 'login.microsoftonline.com', 'home_account_id': 'f8f426a9-5453-4483-befa-e99318c73e7d.72f988bf-86f1-41af-91ab-2d7cd011db47', 'family_id': '1'}
msal.telemetry: Generate or reuse correlation_id: 8f59d426-1087-463b-aa99-020a4d3e338c
msal.application: Cache attempts an RT
urllib3.connectionpool: https://login.microsoftonline.com:443 "POST /72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token HTTP/1.1" 200 5188
msal.token_cache: event={
    "client_id": "04b07795-8ddb-461a-bbee-02f9e1bf7b46",
    "data": {
        "claims": null,
        "refresh_token": "********",
        "scope": [
            "profile",
            "https://management.core.windows.net//.default",
            "openid",
            "offline_access"
        ]
    },
    "environment": "login.microsoftonline.com",
    "grant_type": "refresh_token",
    "params": null,
    "response": {
        "access_token": "********",
        "client_info": "eyJ1aWQiOiJmOGY0MjZhOS01NDUzLTQ0ODMtYmVmYS1lOTkzMThjNzNlN2QiLCJ1dGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3In0",
        "expires_in": 3737,
        "ext_expires_in": 3737,
        "foci": "1",
        "id_token": "********",
        "scope": "https://management.core.windows.net//user_impersonation https://management.core.windows.net//.default",
        "token_type": "Bearer"
    },
    "scope": [
        "https://management.core.windows.net//user_impersonation",
        "https://management.core.windows.net//.default"
    ],
    "skip_account_creation": true,
    "token_endpoint": "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token"
}
cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32?api-version=2021-08-09'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
cli.azure.cli.core.sdk.policies: Request headers:
cli.azure.cli.core.sdk.policies:     'Accept': 'application/json'
cli.azure.cli.core.sdk.policies:     'x-ms-client-request-id': '75087de2-42c4-11ec-a280-00155dd0215b'
cli.azure.cli.core.sdk.policies:     'CommandName': 'baremetalinstance update'
cli.azure.cli.core.sdk.policies:     'ParameterSetName': '--resource-group --instance-name --debug'
cli.azure.cli.core.sdk.policies:     'User-Agent': 'AZURECLI/2.30.0 (DEB) azsdk-python-mgmt-baremetalinfrastructure/1.0.0b1 Python/3.6.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-debian-buster-sid)'
cli.azure.cli.core.sdk.policies:     'Authorization': '*****'
cli.azure.cli.core.sdk.policies: Request body:
cli.azure.cli.core.sdk.policies: This request has no body
urllib3.connectionpool: Starting new HTTPS connection (1): management.azure.com:443
urllib3.connectionpool: https://management.azure.com:443 "GET /subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32?api-version=2021-08-09 HTTP/1.1" 200 None
cli.azure.cli.core.sdk.policies: Response status: 200
cli.azure.cli.core.sdk.policies: Response headers:
cli.azure.cli.core.sdk.policies:     'Cache-Control': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Pragma': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Transfer-Encoding': 'chunked'
cli.azure.cli.core.sdk.policies:     'Content-Type': 'application/json'
cli.azure.cli.core.sdk.policies:     'Content-Encoding': 'gzip'
cli.azure.cli.core.sdk.policies:     'Expires': '-1'
cli.azure.cli.core.sdk.policies:     'Vary': 'Accept-Encoding,Accept-Encoding'
cli.azure.cli.core.sdk.policies:     'x-ms-routing-request-id': 'SOUTHINDIA:20211111T075338Z:e5ed990b-f4fb-4f23-b5fe-008d37c70b8b'
cli.azure.cli.core.sdk.policies:     'x-ms-ratelimit-remaining-subscription-reads': '11998'
cli.azure.cli.core.sdk.policies:     'x-ms-correlation-request-id': 'e5ed990b-f4fb-4f23-b5fe-008d37c70b8b'
cli.azure.cli.core.sdk.policies:     'x-ms-request-id': 'cd149875-dfdc-4186-9885-31dd8ab9e9a0'
cli.azure.cli.core.sdk.policies:     'Strict-Transport-Security': 'max-age=31536000; includeSubDomains'
cli.azure.cli.core.sdk.policies:     'Server': 'nginx/1.19.1'
cli.azure.cli.core.sdk.policies:     'X-Content-Type-Options': 'nosniff'
cli.azure.cli.core.sdk.policies:     'Date': 'Thu, 11 Nov 2021 07:53:37 GMT'
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {
  "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32",
  "location": "centraluseuap",
  "name": "sollabdsm32",
  "tags": {
   "testingapi": "true"
  },
  "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances",
  "systemData": {
   "lastModifiedBy": "shaaga@microsoft.com",
   "lastModifiedByType": "User",
   "lastModifiedAt": "2021-11-11T07:22:48.8578964Z"
  },
  "properties": {
   "azureBareMetalInstanceId": "370c6cd6-5ae6-42bf-91b3-dc01655c8578",
   "powerState": "started",
   "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm32-ppg",
   "hwRevision": "Rev 4.2",
   "hardwareProfile": {
    "hardwareType": "Cisco_UCS",
    "azureBareMetalInstanceSize": "S192"
   },
   "networkProfile": {
    "networkInterfaces": [
     {
      "ipAddress": "10.100.0.32"
     }
    ],
    "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb"
   },
   "storageProfile": {
    "nfsIpAddress": "10.20.211.52",
    "osDisks": [
     {
      "name": "t210_sles_boot_sollabdsm32",
      "diskSizeGB": 50
     }
    ]
   },
   "osProfile": {
    "computerName": "sollabdsm32",
    "osType": "SLES 12 SP3",
    "version": "SLES 12 SP3"
   }
  }
 }
cli.azure.cli.core.commands.client_factory: Getting management service client client_type=BareMetalInfrastructureClient
urllib3.util.retry: Converted retries value: 1 -> Retry(total=1, connect=None, read=None, redirect=None, status=None)
urllib3.connectionpool: Starting new HTTPS connection (1): login.microsoftonline.com:443
urllib3.connectionpool: https://login.microsoftonline.com:443 "GET /72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0/.well-known/openid-configuration HTTP/1.1" 200 1753
msal.authority: openid_config = {'token_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token', 'token_endpoint_auth_methods_supported': ['client_secret_post', 'private_key_jwt', 'client_secret_basic'], 'jwks_uri': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/discovery/v2.0/keys', 'response_modes_supported': ['query', 'fragment', 'form_post'], 'subject_types_supported': ['pairwise'], 'id_token_signing_alg_values_supported': ['RS256'], 'response_types_supported': ['code', 'id_token', 'code id_token', 'id_token token'], 'scopes_supported': ['openid', 'profile', 'email', 'offline_access'], 'issuer': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0', 'request_uri_parameter_supported': False, 'userinfo_endpoint': 'https://graph.microsoft.com/oidc/userinfo', 'authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/authorize', 'device_authorization_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/devicecode', 'http_logout_supported': True, 'frontchannel_logout_supported': True, 'end_session_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/logout', 'claims_supported': ['sub', 'iss', 'cloud_instance_name', 'cloud_instance_host_name', 'cloud_graph_host_name', 'msgraph_host', 'aud', 'exp', 'iat', 'auth_time', 'acr', 'nonce', 'preferred_username', 'name', 'tid', 'ver', 'at_hash', 'c_hash', 'email'], 'kerberos_endpoint': 'https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/kerberos', 'tenant_region_scope': 'WW', 'cloud_instance_name': 'microsoftonline.com', 'cloud_graph_host_name': 'graph.windows.net', 'msgraph_host': 'graph.microsoft.com', 'rbac_url': 'https://pas.windows.net'}
cli.azure.cli.core.auth.credential_adaptor: CredentialAdaptor.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
cli.azure.cli.core.auth.msal_authentication: UserCredential.get_token: scopes=('https://management.core.windows.net//.default',), kwargs={}
msal.application: Cache hit an AT
msal.telemetry: Generate or reuse correlation_id: ae5449a3-e162-46ba-aea9-b35928947ebf
cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32?api-version=2021-08-09'
cli.azure.cli.core.sdk.policies: Request method: 'PATCH'
cli.azure.cli.core.sdk.policies: Request headers:
cli.azure.cli.core.sdk.policies:     'Content-Type': 'application/json'
cli.azure.cli.core.sdk.policies:     'Accept': 'application/json'
cli.azure.cli.core.sdk.policies:     'Content-Length': '2'
cli.azure.cli.core.sdk.policies:     'x-ms-client-request-id': '75087de2-42c4-11ec-a280-00155dd0215b'
cli.azure.cli.core.sdk.policies:     'CommandName': 'baremetalinstance update'
cli.azure.cli.core.sdk.policies:     'ParameterSetName': '--resource-group --instance-name --debug'
cli.azure.cli.core.sdk.policies:     'User-Agent': 'AZURECLI/2.30.0 (DEB) azsdk-python-mgmt-baremetalinfrastructure/1.0.0b1 Python/3.6.10 (Linux-5.10.60.1-microsoft-standard-WSL2-x86_64-with-debian-buster-sid)'
cli.azure.cli.core.sdk.policies:     'Authorization': '*****'
cli.azure.cli.core.sdk.policies: Request body:
cli.azure.cli.core.sdk.policies: {}
urllib3.connectionpool: Starting new HTTPS connection (1): management.azure.com:443
urllib3.connectionpool: https://management.azure.com:443 "PATCH /subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32?api-version=2021-08-09 HTTP/1.1" 200 None
cli.azure.cli.core.sdk.policies: Response status: 200
cli.azure.cli.core.sdk.policies: Response headers:
cli.azure.cli.core.sdk.policies:     'Cache-Control': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Pragma': 'no-cache'
cli.azure.cli.core.sdk.policies:     'Transfer-Encoding': 'chunked'
cli.azure.cli.core.sdk.policies:     'Content-Type': 'application/json'
cli.azure.cli.core.sdk.policies:     'Content-Encoding': 'gzip'
cli.azure.cli.core.sdk.policies:     'Expires': '-1'
cli.azure.cli.core.sdk.policies:     'Vary': 'Accept-Encoding,Accept-Encoding'
cli.azure.cli.core.sdk.policies:     'x-ms-routing-request-id': 'SOUTHINDIA:20211111T075340Z:a8d64fba-86ea-47f6-8505-f5c4f25306c6'
cli.azure.cli.core.sdk.policies:     'x-ms-ratelimit-remaining-subscription-writes': '1199'
cli.azure.cli.core.sdk.policies:     'x-ms-correlation-request-id': 'a8d64fba-86ea-47f6-8505-f5c4f25306c6'
cli.azure.cli.core.sdk.policies:     'x-ms-request-id': 'a944773a-e9fa-47a0-bedc-04d373c4c2fd'
cli.azure.cli.core.sdk.policies:     'Strict-Transport-Security': 'max-age=31536000; includeSubDomains'
cli.azure.cli.core.sdk.policies:     'Server': 'nginx/1.19.1'
cli.azure.cli.core.sdk.policies:     'X-Content-Type-Options': 'nosniff'
cli.azure.cli.core.sdk.policies:     'Date': 'Thu, 11 Nov 2021 07:53:40 GMT'
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {
  "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32",
  "location": "centraluseuap",
  "name": "sollabdsm32",
  "tags": {
   "testingapi": "true"
  },
  "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances",
  "systemData": {
   "lastModifiedBy": "shaaga@microsoft.com",
   "lastModifiedByType": "User",
   "lastModifiedAt": "2021-11-11T07:53:39.6510324Z"
  },
  "properties": {
   "azureBareMetalInstanceId": "370c6cd6-5ae6-42bf-91b3-dc01655c8578",
   "powerState": "started",
   "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm32-ppg",
   "hwRevision": "Rev 4.2",
   "hardwareProfile": {
    "hardwareType": "Cisco_UCS",
    "azureBareMetalInstanceSize": "S192"
   },
   "networkProfile": {
    "networkInterfaces": [
     {
      "ipAddress": "10.100.0.32"
     }
    ],
    "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb"
   },
   "storageProfile": {
    "nfsIpAddress": "10.20.211.52",
    "osDisks": [
     {
      "name": "t210_sles_boot_sollabdsm32",
      "diskSizeGB": 50
     }
    ]
   },
   "osProfile": {
    "computerName": "sollabdsm32",
    "osType": "SLES 12 SP3",
    "version": "SLES 12 SP3"
   }
  }
 }
cli.knack.cli: Event: CommandInvoker.OnTransformResult [<function _resource_group_transform at 0x7f9a5effc268>, <function _x509_from_base64_to_hex_transform at 0x7f9a5effc2f0>]
cli.knack.cli: Event: CommandInvoker.OnFilterResult []
{
  "azureBareMetalInstanceId": "370c6cd6-5ae6-42bf-91b3-dc01655c8578",
  "hardwareProfile": {
    "azureBareMetalInstanceSize": "S192",
    "hardwareType": "Cisco_UCS"
  },
  "hwRevision": "Rev 4.2",
  "id": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourceGroups/DSM05A-T210/providers/Microsoft.BareMetalInfrastructure/bareMetalInstances/sollabdsm32",
  "location": "centraluseuap",
  "name": "sollabdsm32",
  "networkProfile": {
    "circuitId": "/subscriptions/cf471ca4-2535-48fb-b676-684d8f7bfc6e/resourceGroups/T210_DSM05-Circuits/providers/Microsoft.Network/expressRouteCircuits/T210_DSM05-10Gb",
    "networkInterfaces": [
      {
        "ipAddress": "10.100.0.32"
      }
    ]
  },
  "osProfile": {
    "computerName": "sollabdsm32",
    "osType": "SLES 12 SP3",
    "sshPublicKey": null,
    "version": "SLES 12 SP3"
  },
  "partnerNodeId": null,
  "powerState": "started",
  "provisioningState": null,
  "proximityPlacementGroup": "/subscriptions/79a018c7-afdb-4895-af1b-306bc9bd9bc0/resourcegroups/DSM05A-T210/providers/Microsoft.Compute/proximityPlacementGroups/sollabdsm32-ppg",
  "resourceGroup": "DSM05A-T210",
  "storageProfile": {
    "nfsIpAddress": "10.20.211.52",
    "osDisks": [
      {
        "diskSizeGb": 50,
        "lun": null,
        "name": "t210_sles_boot_sollabdsm32"
      }
    ]
  },
  "systemData": {
    "lastModifiedAt": "2021-11-11T07:53:39.6510324Z",
    "lastModifiedBy": "shaaga@microsoft.com",
    "lastModifiedByType": "User"
  },
  "tags": {
    "testingapi": "true"
  },
  "type": "Microsoft.BareMetalInfrastructure/bareMetalInstances"
}
```