### PR TITLE
Set *actual* minimum cli version

### DIFF
--- a/azext_baremetalinfrastructure/azext_metadata.json
+++ b/azext_baremetalinfrastructure/azext_metadata.json
@@ -1,4 +1,4 @@
 {
-    "azext.minCliCoreVersion": "2.54.0",
+    "azext.minCliCoreVersion": "2.56.0",
     "version": "2.0.1"
   }


### PR DESCRIPTION
After prepping the index update in the official azure cli repo with the previous PR. It was flagged that the min required version was 2.56.0